### PR TITLE
Remove alpha testing references from docs - Agents now in open access

### DIFF
--- a/ai-tools/anthropic-sdk.mdx
+++ b/ai-tools/anthropic-sdk.mdx
@@ -48,7 +48,7 @@ Before you begin, ensure you have:
 
 **For best results:**
 - Use API key-based Anthropic authentication from the [Anthropic Console](https://console.anthropic.com/settings/keys)
-- Contact [austin@shinzolabs.com](mailto:austin@shinzolabs.com) for early access to enhanced agent features
+- Explore the [Shinzo Agents platform](/shinzo-agents) for managed agent deployment and orchestration
 </Warning>
 
 ## Setup Guide
@@ -454,6 +454,6 @@ unset ANTHROPIC_BASE_URL
     Add observability to your MCP servers
   </Card>
   <Card title="Contact Support" icon="envelope" href="mailto:austin@shinzolabs.com">
-    Get help or request early access to advanced features
+    Get help or contact us about your use case
   </Card>
 </CardGroup>

--- a/ai-tools/claude-code.mdx
+++ b/ai-tools/claude-code.mdx
@@ -46,7 +46,7 @@ Before you begin, ensure you have:
 
 **For best results:**
 - Use API key-based Anthropic authentication from the [Anthropic Console](https://console.anthropic.com/settings/keys)
-- Contact [austin@shinzolabs.com](mailto:austin@shinzolabs.com) for early access to enhanced agent features
+- Explore the [Shinzo Agents platform](/shinzo-agents) for managed agent deployment and orchestration
 </Warning>
 
 ## Setup Guide
@@ -281,6 +281,6 @@ Or remove them from your shell configuration file and reload your shell.
     Add observability to your MCP servers
   </Card>
   <Card title="Contact Support" icon="envelope" href="mailto:austin@shinzolabs.com">
-    Get help or request early access to advanced features
+    Get help or contact us about your use case
   </Card>
 </CardGroup>

--- a/index.mdx
+++ b/index.mdx
@@ -125,6 +125,6 @@ Why developers choose Shinzo for agent infrastructure.
     icon="envelope"
     href="mailto:austin@shinzolabs.com"
   >
-    Get help or request early access to advanced features.
+    Get help or contact us about your use case.
   </Card>
 </CardGroup>

--- a/shinzo-agents.mdx
+++ b/shinzo-agents.mdx
@@ -1,15 +1,9 @@
 ---
 title: "Shinzo Agents"
-description: "Managed AI agent deployment and orchestration platform - Coming Soon"
+description: "Managed AI agent deployment and orchestration platform"
 ---
 
 # Shinzo Agents
-
-<Info>
-**Alpha Testing in Progress**
-
-Shinzo Agents is currently in alpha testing with select early access partners. This feature provides managed AI agent deployment, orchestration, and monitoring capabilities.
-</Info>
 
 ## What is Shinzo Agents?
 
@@ -43,27 +37,17 @@ Shinzo Agents is a comprehensive platform for deploying, managing, and monitorin
 - MCP server integration
 - Custom agent configurations
 
-## Alpha Testing
+## Getting Started
 
-We're currently working with early access partners to refine the platform before public release. Alpha participants get:
+Shinzo Agents is now available for all users. Get started by:
 
-- **Early access** to all Shinzo Agents features
-- **Direct support** from our engineering team
-- **Influence** on product roadmap and feature prioritization
-- **Discounted pricing** during the alpha period
+1. **Creating your first agent** via the Shinzo dashboard or API
+2. **Configuring agent settings** including model selection, system prompts, and tools
+3. **Deploying and managing** your agents with built-in observability
 
-## Request Early Access
-
-Interested in participating in the alpha program? We'd love to hear from you!
-
-<Card title="Request Alpha Access" icon="envelope" href="mailto:austin@shinzolabs.com?subject=Shinzo%20Agents%20Alpha%20Access">
-  Contact austin@shinzolabs.com to request early access to Shinzo Agents
+<Card title="Get Started with Agents" icon="rocket" href="/agents/configuration">
+  Learn how to create and configure your first Shinzo agent
 </Card>
-
-**In your request, please include:**
-- Your use case for AI agents
-- Expected agent deployment scale
-- Any specific requirements or integrations you need
 
 ## Coming Soon
 
@@ -90,7 +74,7 @@ Want to be notified when Shinzo Agents becomes generally available?
 
 ## Learn More
 
-While Shinzo Agents is in alpha, you can already use our platform for:
+Explore our full platform capabilities:
 
 <CardGroup cols={2}>
   <Card title="MCP Analytics" icon="puzzle-piece" href="/quickstart">


### PR DESCRIPTION
- Remove 'Alpha Testing in Progress' banner from shinzo-agents.mdx
- Replace 'Alpha Testing' section with 'Getting Started' section
- Remove 'Request Early Access' section and replace with getting started card
- Update 'Learn More' intro text (removed 'While Shinzo Agents is in alpha')
- Update all 'request early access' CTAs to 'contact us about your use case'
- Replace early access mentions with links to Shinzo Agents platform
- Updated meta description to remove 'Coming Soon'

Files updated:
- shinzo-agents.mdx (main landing page)
- index.mdx (homepage contact support card)
- ai-tools/anthropic-sdk.mdx (warning box + contact card)
- ai-tools/claude-code.mdx (warning box + contact card)