### PR TITLE
fix: add missing Messages Tab step to Slack app setup docs

### DIFF
--- a/agents/messaging.mdx
+++ b/agents/messaging.mdx
@@ -343,7 +343,19 @@ Before linking, you must create a Slack app and configure it in Shinzo. Slack re
 3. Copy the **App-Level Token** (starts with `xapp-`)
 4. Navigate to **Basic Information** and copy your **Signing Secret**
 
-**Step 4: Configure credentials in your agent**
+**Step 4: Enable the Messages Tab**
+
+This step is required so users can send direct messages to your bot. Without it, Slack shows "Sending messages to this app has been turned off."
+
+1. Navigate to **App Home** in the left sidebar
+2. Scroll down to the **Show Tabs** section
+3. Enable **"Allow users to send Slash commands and messages from the messages tab"**
+
+<Warning>
+If you skip this step, users will see "Sending messages to this app has been turned off" when they try to DM the bot, and the `/link` command will not work.
+</Warning>
+
+**Step 5: Configure credentials in your agent**
 
 Add all three credentials to your agent's configuration:
 


### PR DESCRIPTION
## Summary

- Adds the missing **Step 4: Enable the Messages Tab** to the Slack app setup guide
- Renumbers old Step 4 (Configure credentials) → Step 5
- Includes a `<Warning>` callout explicitly describing the "Sending messages to this app has been turned off" error users will hit if they skip this step

## Root cause

Users following the Slack setup guide couldn't send the `/link` command to their bot — Slack showed "Sending messages to this app has been turned off." The fix is enabling the Messages Tab under **App Home → Show Tabs** in the Slack app settings, but this step was absent from the docs.

## Test plan

- [ ] Follow the updated Slack setup steps end-to-end, confirm the bot accepts DMs after enabling the Messages Tab
- [ ] Verify docs render correctly on docs.shinzo.ai

🤖 Generated with [Claude Code](https://claude.com/claude-code)