### PR TITLE
Add Event Subscriptions step to Slack integration docs

### DIFF
--- a/agents/messaging.mdx
+++ b/agents/messaging.mdx
@@ -356,7 +356,19 @@ This step is required so users can send direct messages to your bot. Without it,
 If you skip this step, users will see "Sending messages to this app has been turned off" when they try to DM the bot, and linking will not work.
 </Warning>
 
-**Step 5: Configure credentials in your agent**
+**Step 5: Enable Event Subscriptions**
+
+1. Navigate to **Event Subscriptions** in the left sidebar and toggle it **on**
+2. Under **Subscribe to bot events**, add the following events:
+   - `app_mention` - To receive messages when your bot is @mentioned
+   - `message.im` - To receive direct messages sent to your bot
+3. Click **Save Changes**
+
+<Warning>
+**Required step!** Your Slack bot will not receive messages without Event Subscriptions enabled. Make sure to add both `app_mention` and `message.im` events.
+</Warning>
+
+**Step 6: Configure credentials in your agent**
 
 Add all three credentials to your agent's configuration:
 


### PR DESCRIPTION
## Summary

Adds the critical **Event Subscriptions** configuration step to the Slack integration documentation. Without this step, Slack bots will not receive messages even if all other setup is correct.

## Changes

- **Added Step 5:** Enable Event Subscriptions (`app_mention` and `message.im` events)
- **Renumbered Step 5 → Step 6:** Configure credentials in your agent
- Includes warning callout emphasizing this is a required step

## Context

Both the **Messages Tab** (Step 4) and **Event Subscriptions** (Step 5) are required:
- **Messages Tab:** Enables the UI for users to send DMs to the bot
- **Event Subscriptions:** Configures backend to receive and process those messages

Without Event Subscriptions, the bot appears functional but silently fails to receive messages.

## Testing

Verified documentation structure and formatting. All existing steps remain intact.
